### PR TITLE
Link to attachments in Show Household page

### DIFF
--- a/resources/views/admin/households/show.blade.php
+++ b/resources/views/admin/households/show.blade.php
@@ -15,6 +15,18 @@
             <li class="list-group-item"><b>Last 4 SSN</b> <span class="pull-right">{{ $object->last4ssn }}</span></li>
             <li class="list-group-item"><b>Preferred Contact Method</b> <span class="pull-right">{{ $object->preferred_contact_method }}</span></li>
           </ul>
+          @for ($i = 0; $i < count($object->attachment); $i++)
+          <ul class="list-group list-group-unbordered">
+            <li class="list-group-item">
+              <b>Attachment {{ $i + 1 }}</b>
+              <span class="pull-right">
+                <a href="/admin/household_attachment/{{ $object->attachment[$i]->id }}" target="_blank">
+                  {{ explode("_", $object->attachment[$i]->path)[1] }}
+                </a>
+              </span>
+            </li>
+          </ul>
+          @endfor
         </div>
         <!-- Right side -->
         <div class="box-profile col-md-6">


### PR DESCRIPTION
Fixes #42.

Added a box for each attachment. Clicking the filename opens the attachment in a new window.

![delme](https://cloud.githubusercontent.com/assets/706854/20457833/fa455ba8-ae61-11e6-9794-87d4429d3bc2.png)