### PR TITLE
Update messaging in the uploader form element

### DIFF
--- a/react-ui/src/app/dashboard/household/components/form/files.js
+++ b/react-ui/src/app/dashboard/household/components/form/files.js
@@ -20,7 +20,16 @@ class Files extends React.PureComponent<any, any> {
                                 <a href={file.url} download>{file.filename}</a>
                             </div>
                         ))}
-
+                    <Row>
+                      <Col xs={12}>
+                        <p>
+                          Save as Draft before uploading form.
+                        </p>
+                        <p class="text-danger">
+                          Reminder: Nominations are not eligible for approval WITHOUT uploaded form.
+                        </p>
+                      </Col>
+                    </Row>
                     {/* Re-used this box in ShowHousehold */}
                     {onChange &&
                         <Row>


### PR DESCRIPTION
I've added the language to the upload element.

- [x] add "Reminder: Nominations are not eligible for approval WITHOUT uploaded form". Do this in red text so it is more noticeable.
- [x]  add "Save as Draft before uploading form" to the end of the nomination form. 

https://codeforcharlotte.atlassian.net/projects/GIFT/issues/GIFT-285?filter=allopenissues