### PR TITLE
Fix seeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cmpd-explorers-christmas-2017",
+  "name": "cmpd-explorers-christmas",
   "version": "2017.1.0",
   "private": true,
   "scripts": {

--- a/server/common/util/converters/boolean.ts
+++ b/server/common/util/converters/boolean.ts
@@ -1,3 +1,4 @@
-const bool = (myValue: string = '') => myValue.toLowerCase() == 'true';
+// Added in a toString because the seeder was throwing an untraceable error >_>
+const bool = (myValue: string = '') => myValue.toString().toLowerCase() == 'true';
 
 export default bool;

--- a/server/entities/abstract/user.ts
+++ b/server/entities/abstract/user.ts
@@ -11,9 +11,10 @@ export default abstract class extends BaseEntity {
 
   @Column('text') email: string;
 
-  @Column() active: boolean;
+  @Column('boolean', { default: true })
+  active: boolean;
 
-  @Column({ default: false })
+  @Column('boolean', { default: false })
   approved: boolean;
 
   @Column('text', { nullable: true })

--- a/server/entities/user.ts
+++ b/server/entities/user.ts
@@ -34,10 +34,10 @@ export default class User extends AbstractUser {
   @Column('int', { name: 'nomination_limit', default: 5 })
   nominationLimit: number;
 
-  @Column({ name: 'email_verified', default: false })
+  @Column('boolean', { name: 'email_verified', default: false })
   emailVerified: boolean;
 
-  @Column({ name: 'confirmation_email', default: false })
+  @Column('boolean', { name: 'confirmation_email', default: false })
   confirmationEmail: boolean;
 
   @Column('text', { name: 'confirmation_code', nullable: true })

--- a/server/seeds/02_user.ts
+++ b/server/seeds/02_user.ts
@@ -45,7 +45,7 @@ export default async (connection: Connection, verbose = true) => {
     active: true,
     approved: true,
     role: 'admin'
-  });
+  } as any);
 
   await developer.save();
 

--- a/server/seeds/child.ts
+++ b/server/seeds/child.ts
@@ -8,7 +8,7 @@ export default async (connection: Connection) => {
   // Add 25 children to the DB
   for (let i = 0; i < 5; i++) {
     const child = Child.fromJSON({
-      householdId: faker.random.number(25) + 1,
+      householdId: faker.random.number(20) + 1,
       firstName: faker.name.firstName(),
       middleName: faker.name.firstName(),
       lastName: faker.name.lastName(),


### PR DESCRIPTION
Seeds were failing as the boolean type on the user tables were not being inferred by Nest (Node 8.9.4) and the `household_id` in the `child` seeder still had a risk of going out of bounds.