### PR TITLE
#188 - Scaffold adoption module

### DIFF
--- a/backend/adoption-module/package.json
+++ b/backend/adoption-module/package.json
@@ -1,12 +1,11 @@
 {
-  "name": "cmpd-adoption-api-module",
+  "name": "cmpd-adoption-api",
   "version": "1.0.0",
   "main": "dist/module.js",
   "license": "MIT",
   "private": true,
   "scripts": {
-    "build": "tsc",
-    "dist:watch": "tsc --watch"
+    "build": "tsc -p tsconfig.build.json"
   },
   "engines": {
     "node": ">=8.9.x"
@@ -27,10 +26,8 @@
   },
   "devDependencies": {
     "@nestjs/testing": "^5.0.0-rc.1",
-    "ts-node-dev": "^1.0.0-pre.21",
-    "cmpd-common-api": "*"
+    "ts-node-dev": "^1.0.0-pre.21"
   },
   "peerDependencies": {
-    "cmpd-common-api": "*"
   }
 }

--- a/backend/adoption-module/package.json
+++ b/backend/adoption-module/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "cmpd-adoption-api-module",
+  "version": "1.0.0",
+  "main": "dist/module.js",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "dist:watch": "tsc --watch"
+  },
+  "engines": {
+    "node": ">=8.9.x"
+  },
+  "dependencies": {
+    "@nestjs/common": "^5.0.0-rc.1",
+    "@nestjs/core": "^5.0.0-rc.1",
+    "@nestjs/swagger": "^1.1.4",
+    "@nestjs/websockets": "^5.0.0-rc.1",
+    "class-transformer": "^0.1.9",
+    "jsonwebtoken": "^8.2.1",
+    "passport": "^0.4.0",
+    "passport-http-bearer": "^1.0.1",
+    "passport-jwt": "^4.0.0",
+    "pug": "^2.0.3",
+    "rambda": "^1.1.5",
+    "rxjs": "6.0.0"
+  },
+  "devDependencies": {
+    "@nestjs/testing": "^5.0.0-rc.1",
+    "ts-node-dev": "^1.0.0-pre.21",
+    "cmpd-common-api": "*"
+  },
+  "peerDependencies": {
+    "cmpd-common-api": "*"
+  }
+}

--- a/backend/adoption-module/src/adoption.module.ts
+++ b/backend/adoption-module/src/adoption.module.ts
@@ -1,0 +1,6 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  modules: []
+})
+export class AdoptionModule {}

--- a/backend/adoption-module/src/module.ts
+++ b/backend/adoption-module/src/module.ts
@@ -1,0 +1,3 @@
+import { AdoptionModule } from './adoption.module';
+
+export { AdoptionModule };

--- a/backend/adoption-module/src/modules/child/child.controller.ts
+++ b/backend/adoption-module/src/modules/child/child.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  InternalServerErrorException,
+  NotFoundException,
+  Param,
+  Query
+  } from '@nestjs/common';
+import { ApiUseTags } from '@nestjs/swagger';
+import { handleErrors, Household } from 'cmpd-common-api';
+import { ChildService } from './child.service';
+
+const errorMap = {
+  default: InternalServerErrorException
+};
+
+const hadnleChildErrors = handleErrors(errorMap);
+
+@Controller('api/adoption/child')
+@ApiUseTags('households')
+export class ChildController {
+  constructor(private readonly childService: ChildService) {}
+
+  @Get()
+  async getAll(@Query('search') search = '', @Query('page') page = 1, @Query('type') type = '') {
+    const results = await this.childService.getAll();
+    return results;
+  }
+
+  @Get('/:id')
+  async getById(@Param('id') id) {
+    try {
+      const child = await this.childService.getById(id);
+
+      if (!child) throw new NotFoundException();
+
+      return child;
+    } catch (error) {
+      hadnleChildErrors(error);
+    }
+  }
+}

--- a/backend/adoption-module/src/modules/child/child.service.ts
+++ b/backend/adoption-module/src/modules/child/child.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { Child } from '../entities/child';
+// import { createPagedResults } from '../lib/table/table';
+
+@Injectable()
+export class ChildService {
+  async getAll({ active = true } = {}) {
+    return await Child.find({ where: { deleted: false } });
+  }
+
+  async getById(id: number) {
+    return await Child.findOneById(id);
+  }
+}

--- a/backend/adoption-module/src/modules/child/children.module.ts
+++ b/backend/adoption-module/src/modules/child/children.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ChildController } from './child.controller';
+import { ChildService } from './child.service';
+
+@Module({
+  controllers: [ChildController],
+  components: [ChildService]
+})
+export class ChildrenModule {}

--- a/backend/adoption-module/src/modules/entities/child.ts
+++ b/backend/adoption-module/src/modules/entities/child.ts
@@ -1,0 +1,80 @@
+import { encOptions } from 'cmpd-common-api';
+import * as moment from 'moment';
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn
+  } from 'typeorm';
+import { ExtendedColumnOptions } from 'typeorm-encrypted';
+
+@Entity('children')
+export class Child extends BaseEntity {
+  private constructor(props) {
+    super();
+    Object.assign(this, props);
+  }
+
+  @PrimaryGeneratedColumn() id: number;
+
+  @Column('int', { name: 'household_id' })
+  householdId: number;
+
+  @Column('varchar', <ExtendedColumnOptions>{
+    name: 'name_first',
+    ...encOptions
+  })
+  firstName: string;
+
+  @Column('varchar', <ExtendedColumnOptions>{ name: 'dob', ...encOptions })
+  dob: string;
+
+  @Column('text') gender: string;
+
+  @Column('boolean', { name: 'bike_want' })
+  wantsBike: boolean = false;
+
+  @Column('text', { name: 'bike_size', nullable: true })
+  bikeSize: string;
+
+  @Column('text', { name: 'bike_style', nullable: true })
+  bikeStyle: string;
+
+  @Column('boolean', { name: 'clothes_want' })
+  wantsClothes: boolean = false;
+
+  @Column('text', { name: 'clothes_size_shirt', nullable: true })
+  clothesShirtSize: string;
+
+  @Column('text', { name: 'clothes_size_pants', nullable: true })
+  clothesPantsSize: string;
+
+  @Column('text', { name: 'clothes_size_coat', nullable: true })
+  clothesCoatSize: string;
+
+  @Column('text', { name: 'shoe_size', nullable: true })
+  shoeSize: string;
+
+  @Column('text', { name: 'favourite_colour', nullable: true })
+  favouriteColor: string;
+
+  @Column('text', { nullable: true })
+  interests: string;
+
+  @Column('text', { name: 'additional_ideas', nullable: true })
+  additionalIdeas: string;
+
+  @Column('boolean') deleted: boolean = false;
+
+  get age() {
+    return moment().diff(this.dob, 'years');
+  }
+
+  static fromJSON(props) {
+    const entity = new Child(props);
+
+    return entity;
+  }
+}

--- a/backend/adoption-module/tsconfig.build.json
+++ b/backend/adoption-module/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "declaration": false,
+    "rootDir": "src",
+    "outDir": "dist",
+    "experimentalDecorators": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["dist", "./**/*.spec.ts"]
+}

--- a/backend/adoption-module/tsconfig.build.json
+++ b/backend/adoption-module/tsconfig.build.json
@@ -1,10 +1,9 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "declaration": false,
+    "declaration": true,
     "rootDir": "src",
-    "outDir": "dist",
-    "experimentalDecorators": true
+    "outDir": "dist"
   },
   "include": ["**/*.ts"],
   "exclude": ["dist", "./**/*.spec.ts"]

--- a/backend/adoption-module/tsconfig.build.json
+++ b/backend/adoption-module/tsconfig.build.json
@@ -1,10 +1,10 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "src",
-    "outDir": "dist"
-  },
-  "include": ["**/*.ts"],
-  "exclude": ["dist", "./**/*.spec.ts"]
+    "outDir": "dist",
+    "paths": {
+      "cmpd-common-api": ["../common/src"]
+    }
+  }
 }

--- a/backend/adoption-module/tsconfig.json
+++ b/backend/adoption-module/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "jsx": "react",
+    "target": "es2017",
+    "moduleResolution": "node",
+    "rootDir": "./src",
+    "experimentalDecorators": true
+  },
+  "exclude": ["node_modules", "dist", "build", "scripts", "webpack", "jest", "src/setupTests.ts", "src/**/*.test.ts*"],
+  "include": ["./src/**/*"]
+}

--- a/backend/adoption-module/tsconfig.json
+++ b/backend/adoption-module/tsconfig.json
@@ -1,15 +1,3 @@
 {
-  "extends": "../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "skipLibCheck": true,
-    "sourceMap": true,
-    "jsx": "react",
-    "target": "es2017",
-    "moduleResolution": "node",
-    "rootDir": "./src",
-    "experimentalDecorators": true
-  },
-  "exclude": ["node_modules", "dist", "build", "scripts", "webpack", "jest", "src/setupTests.ts", "src/**/*.test.ts*"],
-  "include": ["./src/**/*"]
+  "extends": "../tsconfig.base.json"
 }

--- a/backend/common/src/index.ts
+++ b/backend/common/src/index.ts
@@ -1,3 +1,5 @@
+import encOptions from './util/encryption-options';
+export { encOptions };
 export * from './entities';
 export * from './util/logger';
 export * from './util/table';

--- a/backend/nominations-api/package.json
+++ b/backend/nominations-api/package.json
@@ -34,7 +34,8 @@
     "passport-jwt": "^4.0.0",
     "pug": "^2.0.3",
     "rambda": "^1.1.5",
-    "rxjs": "6.0.0"
+    "rxjs": "6.0.0",
+    "cmpd-adoption-api": "*"
   },
   "devDependencies": {
     "@nestjs/testing": "^5.0.0-rc.1",

--- a/backend/nominations-api/src/app.module.ts
+++ b/backend/nominations-api/src/app.module.ts
@@ -1,13 +1,14 @@
 import { MiddlewareConsumer, Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
-// import { typeDefs } from './modules/affiliations';
+import { AdoptionModule } from 'cmpd-adoption-api';
+import { AppController } from './app.controller';
 import { AffiliationsModule } from './modules/affiliations';
 import { AuthModule } from './modules/auth';
 import { CmpdModule } from './modules/cmpd/cmpd.module';
 import { HouseholdsModule } from './modules/households';
 import { TrackingModule } from './modules/tracking';
 import { UsersModule } from './modules/users/users.module';
-import { AppController } from './app.controller';
+// import { typeDefs } from './modules/affiliations';
 
 // const allRoutes = {
 //   path: '*',
@@ -25,7 +26,16 @@ import { AppController } from './app.controller';
 // };
 
 @Module({
-  modules: [GraphQLModule, AuthModule, HouseholdsModule, AffiliationsModule, TrackingModule, UsersModule, CmpdModule],
+  modules: [
+    GraphQLModule,
+    AuthModule,
+    HouseholdsModule,
+    AdoptionModule,
+    AffiliationsModule,
+    TrackingModule,
+    UsersModule,
+    CmpdModule
+  ],
   controllers: [AppController]
 })
 export class AppModule {

--- a/backend/tsconfig.base.json
+++ b/backend/tsconfig.base.json
@@ -8,7 +8,8 @@
     "emitDecoratorMetadata": true,
     "lib": ["esnext", "dom"],
     "paths": {
-      "cmpd-common-api": ["./common/src"]
+      "cmpd-common-api": ["./common/src"],
+      "cmpd-adoption-api-module": ["./adoption-module/src"]
     }
   }
 }

--- a/backend/tsconfig.base.json
+++ b/backend/tsconfig.base.json
@@ -9,7 +9,7 @@
     "lib": ["esnext", "dom"],
     "paths": {
       "cmpd-common-api": ["./common/src"],
-      "cmpd-adoption-api-module": ["./adoption-module/src"]
+      "cmpd-adoption-api": ["./adoption-module/src"]
     }
   }
 }


### PR DESCRIPTION
Scaffolds in the adoption api module. Should just be able to do `yarn start-server` and it will run with the server. Took me a sec to figure out we didn't need `dist:watch` because we have `paths` in `tsconfig` courtesy not having any vanilla JS modules 😆 