### PR TITLE
Allows the table to read and use the full querystring so you can crea…

### DIFF
--- a/react-ui/src/api/household.js
+++ b/react-ui/src/api/household.js
@@ -19,9 +19,10 @@ export function getHousehold(householdId: number): Promise<{household: Household
 
 export function getHouseholdList(
   pageNumber: number = 1,
-  search: ?string
+  search: ?string,
+  nominator_id: ?number
 ): Promise<{response: DataTableResponse<HouseholdType>}> {
-  return get('nominations', 'households', { page: pageNumber, search: search });
+  return get('nominations', 'households', { page: pageNumber, search, nominator_id });
 }
 
 export function createHousehold(json) {

--- a/react-ui/src/app/dashboard/household/list.js
+++ b/react-ui/src/app/dashboard/household/list.js
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { getHouseholdList, deleteNomination } from 'api/household';
 import RecordActionItems from './RecordActionItems';
+import * as querystring from '../../../lib/queryString';
 
 import type { HouseholdType } from 'api/household';
 
@@ -40,7 +41,7 @@ export default class List extends React.Component<{}> {
       isDeleting: false
     };
 
-    this.refetch.bind(this)
+    this.refetch.bind(this);
   }
 
   uploadedFormFormatter(cell: any, row: HouseholdType): React.Node {
@@ -67,7 +68,7 @@ export default class List extends React.Component<{}> {
 
   refetch() {
     const { page, searchText } = this.state;
-    this.table.fetchData(page, searchText);
+    this.table.fetchData({ page, searchText, nominator_id: this.getNominatorId() });
   }
 
   nominatorCellFormatter(cell, row) {
@@ -80,6 +81,11 @@ export default class List extends React.Component<{}> {
         {row.nominator.name_first} {row.nominator.name_last}
       </Link>
     );
+  }
+
+  getNominatorId = () => {
+    const qs = querystring.parse();
+    return qs && qs.nominator_id ? qs.nominator_id : undefined;
   }
 
   submittedCellFormatter = (cell, row) => {
@@ -104,8 +110,10 @@ export default class List extends React.Component<{}> {
     page: number,
     search: ?string
   ): Promise<{ items: HouseholdType[], totalSize: number, sizePerPage: number }> {
+    
+
     this.currentPage = page; // Used for refreshing list when submitting feedback
-    const response: Object = await getHouseholdList(page, search);
+    const response: Object = await getHouseholdList(page, search, this.getNominatorId());
     return { items: response.items, totalSize: response.totalSize, per_page: response.per_page };
   }
 


### PR DESCRIPTION
Allows the datatable to read the entire query string so you can send advanced filter params. Might be a pointless PR as I realized the household list already filters off the nominator last name so we really don't need to focus on a "view nominations by this user" feature...

I'm totally okay with declining this if you don't see a different use case for it.